### PR TITLE
Updated namespace in Helm deploy [Merge once KUBECONFIG Project Secret updated]

### DIFF
--- a/.github/workflows/deploy_helm.yml
+++ b/.github/workflows/deploy_helm.yml
@@ -27,6 +27,6 @@ jobs:
       - name: Deploy Helm Chart
         run: |
           helm upgrade --install niche-explorer helm/niche_explorer \
-            --namespace team-dev-ops
+            --namespace niche-explorer
         env:
           KUBECONFIG_FILE: ${{ secrets.KUBECONFIG }}


### PR DESCRIPTION
Updated the k8s namespace in the Helm deployment GitHub action. 

Since we've switched to a different project on the Rancher cluster, the used namespace had to be adapted.
As this change needs the KUBECONFIG secret to be updated to run the GitHub action successfully, merge this change only after adapting the secret.